### PR TITLE
Add JSON beautifier and Java version selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # DTOgenerator
 Spring Boot DTO產生器
+
+## Features
+- Beautify JSON input for easier editing.
+- Select Java version (1.8 or 17) to switch validation imports between `javax` and `jakarta`.

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/theme-monokai.js"></script>
 </head>
 
-<body class="bg-gradient-to-br from-blue-50 to-primary-100 min-h-screen">
+<body class="bg-gradient-to-br from-primary-100 to-primary-300 min-h-screen">
     <div class="container mx-auto px-4 py-8">
         <header class="mb-8 text-center">
             <h1 class="text-3xl font-bold text-primary-800">Spring Boot DTO Generator</h1>
@@ -55,10 +55,22 @@
                     <p id="programNameError" class="text-xs text-red-500 mt-1 hidden">Program Name is required</p>
                 </div>
                 <div class="mb-4">
+                    <label for="javaVersion" class="block text-sm font-medium text-gray-700 mb-1">Java Version</label>
+                    <select id="javaVersion"
+                        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500">
+                        <option value="8">Java 1.8</option>
+                        <option value="17">Java 17</option>
+                    </select>
+                </div>
+                <div class="mb-4">
                     <label class="block text-sm font-medium text-gray-700 mb-1">JSON Input</label>
                     <div id="jsonEditor" class="editor"></div>
                 </div>
                 <div class="flex space-x-4">
+                    <button id="beautifyBtn"
+                        class="px-4 py-2 bg-primary-500 text-white rounded-md hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition">
+                        Beautify
+                    </button>
                     <button id="parseBtn"
                         class="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition">
                         Parse Structure

--- a/script.js
+++ b/script.js
@@ -41,6 +41,8 @@ const programNameError = document.getElementById('programNameError');
 const parseBtn = document.getElementById('parseBtn');
 const generateBtn = document.getElementById('generateBtn');
 const copyBtn = document.getElementById('copyBtn');
+const beautifyBtn = document.getElementById('beautifyBtn');
+const javaVersionSelect = document.getElementById('javaVersion');
 const structurePanel = document.getElementById('structurePanel');
 const structureContainer = document.getElementById('structureContainer');
 const fieldModal = document.getElementById('fieldModal');
@@ -112,6 +114,16 @@ generateBtn.addEventListener('click', (e) => {
         outputEditor.setValue(javaCode, -1);
     } catch (error) {
         alert("Error generating DTO classes: " + error.message);
+    }
+});
+
+beautifyBtn.addEventListener('click', () => {
+    try {
+        const json = jsonEditor.getValue();
+        const obj = JSON.parse(json);
+        jsonEditor.setValue(JSON.stringify(obj, null, 2), -1);
+    } catch (error) {
+        alert('Invalid JSON: ' + error.message);
     }
 });
 
@@ -313,6 +325,9 @@ function saveFieldConfiguration() {
 }
 
 function generateClass(className, fields) {
+    const validationPackage = javaVersionSelect.value === '17'
+        ? 'jakarta.validation.constraints'
+        : 'javax.validation.constraints';
     const imports = new Set([
         'import lombok.Data;',
         'import java.io.Serial;',
@@ -326,10 +341,10 @@ function generateClass(className, fields) {
 
         if (cfg.jsonAlias) imports.add('import com.fasterxml.jackson.annotation.JsonAlias;');
         if (cfg.required) {
-            if (cfg.type === 'String') imports.add('import javax.validation.constraints.NotBlank;');
-            else imports.add('import javax.validation.constraints.NotNull;');
+            if (cfg.type === 'String') imports.add(`import ${validationPackage}.NotBlank;`);
+            else imports.add(`import ${validationPackage}.NotNull;`);
         }
-        if (cfg.maxLength) imports.add('import javax.validation.constraints.Size;');
+        if (cfg.maxLength) imports.add(`import ${validationPackage}.Size;`);
         if (cfg.type === 'BigDecimal') imports.add('import java.math.BigDecimal;');
         if (cfg.type === 'LocalDate') imports.add('import java.time.LocalDate;');
         if (cfg.type === 'LocalDateTime') imports.add('import java.time.LocalDateTime;');

--- a/style.css
+++ b/style.css
@@ -11,3 +11,7 @@
 .modal-container {
     transition: transform 0.25s ease;
 }
+
+body {
+    background-color: #fde68a;
+}


### PR DESCRIPTION
## Summary
- add Beautify button to format JSON input
- allow choosing Java 1.8 or 17 to switch validation imports
- deepen background color to richer yellow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ccb85856883248a3da67fda412b4f