### PR TITLE
Integrate parse step into Generate DTO

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,13 +71,8 @@
                         class="px-4 py-2 bg-primary-500 text-white rounded-md hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition">
                         Beautify
                     </button>
-                    <button id="parseBtn"
-                        class="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition">
-                        Parse Structure
-                    </button>
                     <button id="generateBtn"
-                        class="px-4 py-2 bg-amber-500 text-white rounded-md hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 transition"
-                        disabled>
+                        class="px-4 py-2 bg-amber-500 text-white rounded-md hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 transition">
                         Generate DTO
                     </button>
                 </div>

--- a/script.js
+++ b/script.js
@@ -38,7 +38,6 @@ let rootClassName = "";
 
 const programNameInput = document.getElementById('programName');
 const programNameError = document.getElementById('programNameError');
-const parseBtn = document.getElementById('parseBtn');
 const generateBtn = document.getElementById('generateBtn');
 const copyBtn = document.getElementById('copyBtn');
 const beautifyBtn = document.getElementById('beautifyBtn');
@@ -60,12 +59,12 @@ function validateProgramName() {
     programNameError.classList.add('hidden');
     return true;
 }
-
-parseBtn.addEventListener('click', (e) => {
+generateBtn.addEventListener('click', (e) => {
     if (!validateProgramName()) {
         e.preventDefault();
         return;
     }
+
     try {
         const jsonInput = jsonEditor.getValue();
         const jsonObj = JSON.parse(jsonInput);
@@ -89,22 +88,6 @@ parseBtn.addEventListener('click', (e) => {
         fieldConfigurations = {};
         displayStructure(jsonStructure, rootClassName);
         structurePanel.classList.remove('hidden');
-        generateBtn.disabled = false;
-
-    } catch (error) {
-        alert("Error parsing JSON: " + error.message);
-    }
-});
-
-generateBtn.addEventListener('click', (e) => {
-    if (!validateProgramName()) {
-        e.preventDefault();
-        return;
-    }
-
-    try {
-        const programName = programNameInput.value.trim();
-        if (!programName) throw new Error("Program name is required");
 
         const classes = extractClasses(jsonStructure, rootClassName);
         let javaCode = '';


### PR DESCRIPTION
## Summary
- Drop standalone Parse Structure button and fold its behavior into Generate DTO
- Generating DTO now automatically parses the JSON before output

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688cd283b6148324b3a91f8fe6dbf2c5