### PR TITLE
Propagate @Valid annotations to parent fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Spring Boot DTO產生器
 ## Features
 - Beautify JSON input for easier editing.
 - Select Java version (1.8 or 17) to switch validation imports between `javax` and `jakarta`.
+- Automatically adds `@Valid` to parent fields when nested fields have validation constraints.


### PR DESCRIPTION
## Summary
- track nested validation needs and cascade @Valid to parent DTO fields
- document @Valid propagation behavior in README

## Testing
- `node --check script.js && echo 'syntax ok'`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f88f1b10883248d7671eadd27f607